### PR TITLE
refactor: env 사용 구조 조정

### DIFF
--- a/src/app/(routes)/login/page.tsx
+++ b/src/app/(routes)/login/page.tsx
@@ -5,10 +5,12 @@ import PageInfo from "@/app/_components/PageInfo";
 import { Button, Card, CardBody } from "@nextui-org/react";
 import GoogleIcon from "@/app/_components/icon/GoogleIcon";
 import React from "react";
-//import env from "@/app/_configs/env";
 
 const Login = () => {
-    const googleAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}&access_type=offline&prompt=consent&redirect_uri=${process.env.NEXT_PUBLIC_FRONTEND_URL}login/oauth&response_type=code&scope=email profile`;
+
+    const redirectUri = `${process.env.NEXT_PUBLIC_FRONTEND_URL}/login/oauth`;
+
+    const googleAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}&access_type=offline&prompt=consent&redirect_uri=${redirectUri}&response_type=code&scope=email profile`;
     return (
         <div className="min-h-screen">
             <PageInfo title="로그인" description="계속하려면 Google로 로그인하세요." />

--- a/src/app/_configs/env.ts
+++ b/src/app/_configs/env.ts
@@ -1,7 +1,0 @@
-const env = {
-  apiUrl: process.env.NEXT_PUBLIC_API_URL ?? '',
-  frontendUrl: process.env.NEXT_PUBLIC_FRONTEND_URL ?? '',
-  googleClientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? '',
-};
-
-export default env;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,6 @@ import { Providers } from "./providers";
 import "./globals.css";
 import Header from "./_components/header/Header";
 import Footer from "./_components/Footer";
-import env from "./_configs/env"
 import * as process from "process";
 
 export const metadata: Metadata = {
@@ -15,7 +14,7 @@ export const metadata: Metadata = {
     openGraph: {
         title: "한입코딩",
         description: "매일매일 배우는 맞춤형 코딩 학습 웹사이트, 한입코딩",
-        url: env.frontendUrl || "http://1bite-coding.duckdns.org",
+        url: `${process.env.NEXT_PUBLIC_FRONTEND_URL}` || "http://one-bite-fe.site",
         images: [
             {
                 url: `${process.env.NEXT_PUBLIC_FRONTEND_URL}/og-image.png`,


### PR DESCRIPTION
NEXT_PUBLIC_FRONTEND_URL은 순수 프론트 주소만 가리킴.
환경변수 사용할 때 뒤에 /login/oauth 붙여서 구글 리디렉션 uri로 사용하도록 변경

추후 유지보수 시 (본인)헷갈림 방지