### PR TITLE
Feature/modify main page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { getStreak } from "@/utils/user";
 import React, { useState, useEffect} from "react";
 import ProgressCard from "app/_components/card/ProgressCard";
 import {fetchTotalProblemNumber} from "@/utils/apis/problemStats";
+import {fetchUserStreak} from "@/utils/apis/streakApi";
 
 export default function Page() {
     const router = useRouter();
@@ -25,16 +26,22 @@ export default function Page() {
             return;
         }
 
-        const mystreak = getStreak();
-        setTodayStreakLeft(mystreak.todayStreakQuizLeft);
-        setWeeklyStreakHistory(mystreak.streakHistory);
+        const syncStreak = async () => {
+            const userStreak = await fetchUserStreak();
+            localStorage.setItem("userStreak", JSON.stringify(userStreak));
+            const mystreak = getStreak();
+            setTodayStreakLeft(mystreak.todayStreakQuizLeft);
+            setWeeklyStreakHistory(mystreak.streakHistory);
+        }
 
         const loadStats = async () => {
             const data = await fetchTotalProblemNumber();
             setProblemStats({ total: data.total, solved: data.solved });
-            setIsReady(true);
         };
-        loadStats();
+
+        Promise.all([syncStreak(),loadStats()]).then(()=>{
+            setIsReady(true);
+        })
 
     }, [router]);
     

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import DailyStreakCard from "app/_components/card/DailyStreakCard";
 import CourseButton from "./_components/buttons/CourseButton";
 import ResumeCourseButton from "app/_components/buttons/ResumeCourseButton";
@@ -9,11 +10,21 @@ import ProgressCard from "app/_components/card/ProgressCard";
 import {fetchTotalProblemNumber} from "@/utils/apis/problemStats";
 
 export default function Page() {
+    const router = useRouter();
+    const [isReady, setIsReady] = useState(false);
     const [todayStreakLeft, setTodayStreakLeft] = useState(0);
     const [weeklyStreakHistory, setWeeklyStreakHistory] = useState<string[]>([]);
     const [problemStats, setProblemStats] = useState<{total:number, solved:number}>({total:1,solved:0});
 
     useEffect(() => {
+        const token = localStorage.getItem("accessToken");
+        const email = localStorage.getItem("user_email");
+
+        if(!token || !email) {
+            router.replace("/login");
+            return;
+        }
+
         const mystreak = getStreak();
         setTodayStreakLeft(mystreak.todayStreakQuizLeft);
         setWeeklyStreakHistory(mystreak.streakHistory);
@@ -21,17 +32,18 @@ export default function Page() {
         const loadStats = async () => {
             const data = await fetchTotalProblemNumber();
             setProblemStats({ total: data.total, solved: data.solved });
+            setIsReady(true);
         };
         loadStats();
 
-    }, []);
+    }, [router]);
     
     function handleClearLocalStorage() {
         localStorage.clear();
         alert("로컬 스토리지가 초기화되었습니다.");
     }
 
-
+    if (!isReady) return null;
 
     return (
 


### PR DESCRIPTION
메인 페이지 접속 시 로컬 스토리지 정보를 바탕으로 로그인이 안 되어있으면 로그인 페이지로 자동으로 이동하도록 설정
로그인 페이지에서 뒤로가기로 메인페이지 접속 방지
메인 페이지 완전 렌더링 전 필요한 데이터 확인하고 로그인 페이지로 리디렉션
메인 페이지에서 먼저 userStreak정보를 받아오고 그 뒤에 스트릭 정보를 로컬 스토리지에서 읽어오도록 수정